### PR TITLE
refactor: restructure Dockerfile for multi-stage build and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM python:3.12-slim
-
-WORKDIR /backend
-
-COPY . /backend/
-
+FROM python:3.12-slim AS builder
+WORKDIR /build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-ENV PATH="/root/.local/bin:${PATH}"
-RUN uv sync --frozen
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project
 
+FROM python:3.12-slim
+WORKDIR /backend
+COPY --from=builder /build/.venv /backend/.venv
+COPY src/ /backend/src/
+COPY output/ /backend/output/
+ENV PATH="/backend/.venv/bin:$PATH"
 EXPOSE 8081
-
-CMD ["uv", "run",  "/backend/src/serve_model.py"]
+CMD ["python", "/backend/src/serve_model.py"]


### PR DESCRIPTION
- Separated dependency installation - builder vs runtime
- Used --no-install-project flag to install only external dependencies
- Selective copying of only src/ and output/ to runtime stage
- Removed unnecessary files (smsspamcollection/, uv binary, etc.)
- Image size reduced from 823MB to 693MB (16% reduction)

<img width="769" height="91" alt="image" src="https://github.com/user-attachments/assets/9ff818b7-4e5a-493c-989c-5aecc306c680" />

Issue: https://github.com/doda25-team2/operation/issues/5