### PR TITLE
add GitHub Actions workflow for building and pushing Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,64 @@
+# This workflow builds a Docker image from the repository's Dockerfile,
+# tags it automatically using the Git tag (e.g. v1.0.0), and pushes it to GHCR.
+#
+# Most of the structure follows the official GitHub documentation:
+# https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images
+
+name: Release Docker image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}   # ghcr.io/doda25-team2/model-service
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Use the Git tag as the image version (e.g. "v1.0.0")
+            type=ref,event=tag
+            # Also publish a "latest" tag
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true                      
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Created `.github/workflows/docker-image.yml`.

Followed the official documentation:
[https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages](https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages)

The workflow is triggered when pushing a version tag (e.g., `v1.0.0`).
It automatically builds the Docker image and publishes it to the GitHub Container Registry using the tag as the image version.

Tested locally using the **act** CLI:
[https://github.com/nektos/act](https://github.com/nektos/act)

Issue: [https://github.com/doda25-team2/operation/issues/8](https://github.com/doda25-team2/operation/issues/8)
