### PR TITLE
f6 Feat: flexible containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ COPY --from=builder /build/.venv /backend/.venv
 COPY src/ /backend/src/
 COPY output/ /backend/output/
 ENV PATH="/backend/.venv/bin:$PATH"
+ENV MODEL_SERVICE_PORT=8081
 EXPOSE 8081
 CMD ["python", "/backend/src/serve_model.py"]

--- a/src/serve_model.py
+++ b/src/serve_model.py
@@ -52,5 +52,9 @@ def predict():
     return jsonify(res)
 
 if __name__ == '__main__':
-    #clf = joblib.load(OUTPUT_PATH / 'model.joblib')
-    app.run(host="0.0.0.0", port=8081, debug=True)
+  # Read port from environment so container runtime can override it
+  import os
+  # default to 8081 if MODEL_SERVICE_PORT is not set
+  port = int(os.getenv("MODEL_SERVICE_PORT", "8081"))
+  #clf = joblib.load(OUTPUT_PATH / 'model.joblib')
+  app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
This PR implements the model-service portion of F6 by making the service port fully configurable.

- MODEL_SERVICE_PORT env variable now determines the uvicorn startup port  
- Default remains 8081 to maintain compatibility  
- Container can now be run on any port without code changes

### How to verify

1. Build locally:
   docker build -t sms-model:dev .

2. Run with default port:
   docker run --rm -p 8081:8081 sms-model:dev
   → Expected: Uvicorn starts on port 8081

3. Run with overridden port:
   docker run --rm \
     -e MODEL_SERVICE_PORT=9091 \
     -p 9091:9091 \
     sms-model:dev
   → Expected: Uvicorn starts on port 9091