### PR TITLE
Improve Version Management

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,6 +59,8 @@ jobs:
           push: true                      
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SERVICE_VERSION=${{ github.ref_name }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,8 @@
 #
 # Most of the structure follows the official GitHub documentation:
 # https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images
+# There are some additional features to be aware of:
+# - if you push a tag and forget to update the pyproject.toml, the build will fail and you'll need to rebuild.
 
 name: Release Docker image
 
@@ -28,6 +30,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Verify tag matches pyproject.toml
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]+' pyproject.toml)
+          
+          if [[ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]]; then
+            echo "`pyproject.toml` and `git tag` do not match:"
+            echo "   git tag:        $TAG_VERSION"
+            echo "   pyproject.toml: $PYPROJECT_VERSION"
+            echo ""
+            echo "Please update pyproject.toml to match the tag before releasing."
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/train-release.yml
+++ b/.github/workflows/train-release.yml
@@ -1,7 +1,27 @@
+# This workflow trains the ML model and releases it as a GitHub release.
+# It uses semantic versioning with compatibility-based interpretation:
+#   - MAJOR: Format/serialization changes (breaks loading)
+#   - MINOR: Input/output schema changes (breaks inference)  
+#   - PATCH: Retraining with same pipeline (performance only)
+
 name: Train & Release Model
 
 on:
   workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      release_notes:
+        description: 'Release notes (optional)'
+        required: false
+        type: string
 
 jobs:
   train-release:
@@ -36,22 +56,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          LATEST=$(gh release list --limit 1 --json tagName -q '.[0].tagName' || true)
+          # Find the latest Model-v* release
+          LATEST=$(gh release list --limit 100 --json tagName -q '[.[].tagName | select(startswith("Model-v"))] | sort | reverse | .[0]' || true)
 
-          if [[ -z "$LATEST" || ! "$LATEST" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            LATEST="v0.0.0"
+          if [[ -z "$LATEST" || ! "$LATEST" =~ ^Model-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            LATEST="Model-v0.0.0"
           fi
 
-          VER=${LATEST#v}
+          echo "Latest model release: $LATEST"
+
+          # Strip 'Model-v' prefix
+          VER=${LATEST#Model-v}
           IFS='.' read -r major minor patch <<< "$VER"
 
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-
-          if [[ "$COMMIT_MSG" == *"#major"* ]]; then
+          # Bump based on manual input
+          BUMP_TYPE="${{ inputs.bump_type }}"
+          
+          if [[ "$BUMP_TYPE" == "major" ]]; then
             major=$((major + 1))
             minor=0
             patch=0
-          elif [[ "$COMMIT_MSG" == *"#minor"* ]]; then
+          elif [[ "$BUMP_TYPE" == "minor" ]]; then
             minor=$((minor + 1))
             patch=0
           else
@@ -60,6 +85,77 @@ jobs:
 
           NEW_VERSION="Model-v$major.$minor.$patch"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "VERSION_NUMBER=$major.$minor.$patch" >> $GITHUB_ENV
+          echo "New version: $NEW_VERSION"
+
+      - name: Generate model metadata
+        run: |
+          # Get accuracy from the training output
+          ACCURACY=$(uv run python -c "
+          import joblib
+          from sklearn.model_selection import train_test_split
+          from sklearn.metrics import accuracy_score
+          import pandas as pd
+
+          # Load data and model
+          messages = pd.read_csv('smsspamcollection/SMSSpamCollection', sep='\t', names=['label', 'message'])
+          preprocessed = joblib.load('output/preprocessed_data.joblib')
+          model = joblib.load('output/model.joblib')
+
+          # Split same as training
+          X_train, X_test, y_train, y_test = train_test_split(
+              preprocessed, messages['label'], test_size=0.3, random_state=101
+          )
+
+          # Calculate accuracy
+          predictions = model.predict(X_test)
+          accuracy = accuracy_score(y_test, predictions)
+          print(f'{accuracy:.4f}')
+          ")
+
+          # Get dataset info
+          DATASET_SAMPLES=$(wc -l < smsspamcollection/SMSSpamCollection | tr -d ' ')
+
+          # Get package versions
+          PYTHON_VERSION=$(python --version | cut -d' ' -f2)
+          SKLEARN_VERSION=$(uv run python -c "import sklearn; print(sklearn.__version__)")
+          NLTK_VERSION=$(uv run python -c "import nltk; print(nltk.__version__)")
+          JOBLIB_VERSION=$(uv run python -c "import joblib; print(joblib.__version__)")
+
+          # Create metadata JSON
+          cat > output/model_metadata.json << EOF
+          {
+            "model_version": "$NEW_VERSION",
+            "version_number": "$VERSION_NUMBER",
+            "trained_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "training_commit": "${{ github.sha }}",
+            "training_code_url": "https://github.com/${{ github.repository }}/tree/${{ github.sha }}",
+            "triggered_by": "${{ github.actor }}",
+            "environment": {
+              "python": "$PYTHON_VERSION",
+              "scikit_learn": "$SKLEARN_VERSION",
+              "nltk": "$NLTK_VERSION",
+              "joblib": "$JOBLIB_VERSION"
+            },
+            "performance": {
+              "accuracy": $ACCURACY,
+              "classifier": "DecisionTreeClassifier"
+            },
+            "dataset": {
+              "name": "SMSSpamCollection",
+              "samples": $DATASET_SAMPLES
+            },
+            "compatibility": {
+              "min_service_version": "v1.0.0",
+              "format": "joblib",
+              "input_schema": "text_string",
+              "output_schema": "ham_or_spam"
+            }
+          }
+          EOF
+
+          echo "Generated metadata:"
+          cat output/model_metadata.json
 
       - name: Create GitHub Release
         env:
@@ -70,8 +166,33 @@ jobs:
             exit 0
           fi
 
+          # Build release notes
+          NOTES="## $NEW_VERSION
+
+          **Trained at:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          **Commit:** [${{ github.sha }}](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
+          **Triggered by:** @${{ github.actor }}
+          **Bump type:** ${{ inputs.bump_type }}
+
+          ### Performance
+          - Classifier: Decision Tree
+          - Accuracy: $(cat output/model_metadata.json | grep -o '"accuracy": [0-9.]*' | cut -d' ' -f2)
+
+          ### Compatibility
+          - Minimum service version: v1.0.0
+          - Format: joblib (scikit-learn $(uv run python -c "import sklearn; print(sklearn.__version__)"))
+
+          ### Versioning Scheme
+          This project uses **compatibility-based semantic versioning** for models:
+          - **MAJOR**: Format/serialization changes (breaks loading)
+          - **MINOR**: Input/output schema changes (breaks inference)
+          - **PATCH**: Retraining with same pipeline (performance only)
+
+          ${{ inputs.release_notes }}"
+
           gh release create "$NEW_VERSION" \
             output/model.joblib \
             output/preprocessor.joblib \
-            --title "$NEW_VERSION"
-
+            output/model_metadata.json \
+            --title "$NEW_VERSION" \
+            --notes "$NOTES"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Multi-stage Dockerfile for the SMS Spam Detection Model Service
+# Supports F3 (Containerization), F4 (Multi-architecture), F5 (Multi-stage)
+
 FROM python:3.12-slim AS builder
 WORKDIR /build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -6,16 +9,41 @@ RUN uv sync --frozen --no-install-project
 
 FROM python:3.12-slim
 WORKDIR /backend
+
+# Model compatibility labels (for documentation and tooling)
+LABEL org.opencontainers.image.title="SMS Spam Model Service"
+LABEL org.opencontainers.image.description="ML model service for SMS spam detection"
+LABEL org.opencontainers.image.source="https://github.com/doda25-team2/model-service"
+LABEL model.min-version="Model-v1.0.0"
+LABEL model.format="joblib"
+LABEL model.input-schema="text_string"
+LABEL model.output-schema="ham_or_spam"
+
+# Volume for model files (F10: Decoupled Model)
 VOLUME ["/models"]
 
+# Model configuration - can be overridden at runtime
 ENV MODEL_PATH=/models/model.joblib
 ENV PREPROCESSOR_PATH=/models/preprocessor.joblib
+ENV METADATA_PATH=/models/model_metadata.json
+
+# Default model URLs - downloads latest model on startup if not mounted
 ENV DEFAULT_MODEL_URL="https://github.com/doda25-team2/model-service/releases/latest/download/model.joblib"
 ENV DEFAULT_PREPROCESSOR_URL="https://github.com/doda25-team2/model-service/releases/latest/download/preprocessor.joblib"
+ENV DEFAULT_METADATA_URL="https://github.com/doda25-team2/model-service/releases/latest/download/model_metadata.json"
 
+# Service version - should be updated by CI/CD during release
+# This allows runtime version reporting via /health endpoint
+ARG SERVICE_VERSION=v1.0.0
+ENV SERVICE_VERSION=${SERVICE_VERSION}
+
+# Copy virtual environment and source code
 COPY --from=builder /build/.venv /backend/.venv
 COPY src/ /backend/src/
 ENV PATH="/backend/.venv/bin:$PATH"
+
+# Port configuration (F6: Flexible Containers)
 ENV MODEL_SERVICE_PORT=8081
 EXPOSE 8081
+
 CMD ["python", "/backend/src/serve_model.py"]

--- a/README.md
+++ b/README.md
@@ -1,22 +1,206 @@
-# SMS Checker Backend
+# SMS Checker Model Service
 
-To start the SMS-checker back-end server up, after having cloned this reporistory and navigated to the root directory:
+Backend ML service for SMS spam detection. Part of the DODA A1 assignment.
 
+## Quick Start
 
 ```bash
 docker build -t model-service .
 docker run -d -p 8081:8081 model-service
 ```
 
-The server will start on port 8081.
-Once its startup has finished, you can either access [localhost:8081/apidocs](http://localhost:8081/apidocs) in your browser to interact with the service, or you send `POST` requests to request predictions, for example with `curl`:
+The server will start on port 8081. Access the API docs at [localhost:8081/apidocs](http://localhost:8081/apidocs).
+
+### Example Request
 
 ```bash
-    $ curl -X POST "http://localhost:8081/predict" -H "Content-Type: application/json" -d '{"sms": "test ..."}'
-
-    {
-      "classifier": "decision tree",
-      "result": "ham",
-      "sms": "test ..."
-    }
+curl -X POST "http://localhost:8081/predict" \
+  -H "Content-Type: application/json" \
+  -d '{"sms": "Congratulations! You have won a free prize!"}'
 ```
+
+Response:
+```json
+{
+  "classifier": "decision tree",
+  "result": "spam",
+  "sms": "Congratulations! You have won a free prize!",
+  "service_version": "v1.0.0",
+  "model_version": "Model-v1.0.0"
+}
+```
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/predict` | POST | Classify an SMS as spam or ham |
+| `/health` | GET | Health check with version information |
+| `/version` | GET | Detailed version information |
+| `/apidocs` | GET | Swagger API documentation |
+
+## Versioning Strategy
+
+This repository uses **two separate versioning tracks** for different artifacts:
+
+### 1. Container Releases (`v{major}.{minor}.{patch}`)
+
+Follows the [semantic versioning](https://semver.org/) convention.
+
+### 2. Model Releases (`Model-v{major}.{minor}.{patch}`)
+
+**What**: Trained ML model artifacts (`.joblib` files)  
+**Where**: GitHub Releases (attached assets)  
+**Release Trigger**: Manual workflow dispatch
+
+Developers should manually decide when to re-traing of a model is neccesary and
+follow these rules:
+
+**Compatibility-Based Semantic Versioning:**
+- **MAJOR**: Format/serialization changes (breaks model loading)
+- **MINOR**: Input/output schema changes (breaks inference pipeline)
+- **PATCH**: Retraining with same pipeline (performance improvements only)
+
+**Release Assets:**
+- `model.joblib` - Trained classifier model
+- `preprocessor.joblib` - Text preprocessing pipeline
+- `model_metadata.json` - Training metadata and compatibility info
+
+### Compatibility Matrix
+
+The container validates model compatibility at startup using `model_metadata.json`:
+
+```json
+{
+  "compatibility": {
+    "min_service_version": "v1.0.0",
+    "format": "joblib",
+    "input_schema": "text_string",
+    "output_schema": "ham_or_spam"
+  }
+}
+```
+
+Check compatibility via the `/health` endpoint:
+
+```bash
+curl http://localhost:8081/health
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL_SERVICE_PORT` | `8081` | Port the service listens on |
+| `MODEL_PATH` | `/models/model.joblib` | Path to model file |
+| `PREPROCESSOR_PATH` | `/models/preprocessor.joblib` | Path to preprocessor file |
+| `METADATA_PATH` | `/models/model_metadata.json` | Path to metadata file |
+| `DEFAULT_MODEL_URL` | GitHub latest | URL to download model if missing |
+| `DEFAULT_PREPROCESSOR_URL` | GitHub latest | URL to download preprocessor if missing |
+| `SERVICE_VERSION` | `v1.0.0` | Reported service version |
+
+### Using a Specific Model Version
+
+By default, the container downloads the latest model. To pin a specific version:
+
+```bash
+# Option 1: Mount local model files
+docker run -d -p 8081:8081 \
+  -v /path/to/models:/models \
+  model-service
+
+# Option 2: Override download URLs
+docker run -d -p 8081:8081 \
+  -e DEFAULT_MODEL_URL="https://github.com/doda25-team2/model-service/releases/download/Model-v1.2.3/model.joblib" \
+  -e DEFAULT_PREPROCESSOR_URL="https://github.com/doda25-team2/model-service/releases/download/Model-v1.2.3/preprocessor.joblib" \
+  model-service
+```
+
+## Development
+
+### Training the Model Locally
+
+```bash
+# Install dependencies
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv sync
+
+# Download dataset
+uv run python src/get_data.py
+
+# Preprocess data
+uv run python src/text_preprocessing.py
+
+# Train model
+uv run python src/text_classification.py
+```
+
+### Running Locally (Development)
+
+```bash
+uv run python src/serve_model.py
+```
+
+### Creating a Model Release
+
+1. Go to **Actions** → **Train & Release Model**
+2. Click **Run workflow**
+3. Select version bump type:
+   - `patch` - Retraining with same pipeline
+   - `minor` - Changed preprocessing/features
+   - `major` - Changed model format/serialization
+4. Optionally add release notes
+5. Click **Run workflow**
+
+### Creating a Container Release
+
+1. Create and push a Git tag:
+   ```bash
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+2. The **Release Docker image** workflow will automatically build and push to GHCR
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph repo["GitHub Repository"]
+        subgraph workflows["GitHub Actions"]
+            W1["train-release.yml<br/>(manual trigger)"]
+            W2["docker-image.yml<br/>(on tag v*)"]
+        end
+        
+        CODE["Source Code"]
+        TAG["Git Tag: v1.0.0"]
+        
+        subgraph releases["Releases"]
+            MV["Model-v1.0.0"]
+            ASSETS["model.joblib<br/>preprocessor.joblib<br/>model_metadata.json"]
+            MV --- ASSETS
+        end
+        
+        subgraph ghcr["Container Registry (ghcr.io)"]
+            IMG["model-service:v1.0.0<br/>model-service:latest"]
+        end
+        
+        CODE --> W1
+        TAG -->|"triggers"| W2
+        W1 -->|"trains & releases"| releases
+        W2 -->|"builds & pushes"| ghcr
+    end
+    
+    subgraph runtime["Runtime"]
+        subgraph container["Docker Container"]
+            MODELS["/models/<br/>├── model.joblib<br/>├── preprocessor.joblib<br/>└── model_metadata.json"]
+            API["Flask API :8081<br/>/predict  /health  /version"]
+            MODELS --> API
+        end
+    end
+    
+    ghcr -->|"docker pull"| container
+    releases -.->|"downloads on startup"| MODELS
+```
+

--- a/src/serve_model.py
+++ b/src/serve_model.py
@@ -1,25 +1,30 @@
 """
-Flask API of the SMS Spam detection model model.
+Flask API of the SMS Spam detection model.
 """
-#stdlib
-#external
+# stdlib
+import os
+import json
+from pathlib import Path
+
+# external
 import joblib
 from flask import Flask, jsonify, request
 from flasgger import Swagger
-import pandas as pd
-#internal
+import requests
+
+# internal
 from config import OUTPUT_PATH
 from text_preprocessing import prepare, _extract_message_len, _text_process
-import os
-import requests
-from pathlib import Path
-import joblib
+
+# Service version - should match container release tags
+SERVICE_VERSION = os.getenv("SERVICE_VERSION", "v1.0.0")
 
 app = Flask(__name__)
 swagger = Swagger(app)
 
 MODEL_PATH = Path(os.getenv("MODEL_PATH", "/models/model.joblib"))
 PREPROCESSOR_PATH = Path(os.getenv("PREPROCESSOR_PATH", "/models/preprocessor.joblib"))
+METADATA_PATH = Path(os.getenv("METADATA_PATH", "/models/model_metadata.json"))
 
 DEFAULT_MODEL_URL = os.getenv(
     "DEFAULT_MODEL_URL",
@@ -31,26 +36,164 @@ DEFAULT_PREPROCESSOR_URL = os.getenv(
     "https://github.com/doda25-team2/model-service/releases/latest/download/preprocessor.joblib"
 )
 
-def download_if_missing(local_path: Path, url: str):
+DEFAULT_METADATA_URL = os.getenv(
+    "DEFAULT_METADATA_URL",
+    "https://github.com/doda25-team2/model-service/releases/latest/download/model_metadata.json"
+)
+
+# Store loaded model metadata
+model_metadata = None
+
+
+def download_if_missing(local_path: Path, url: str, required: bool = True):
+    """Download a file from URL if it doesn't exist locally."""
     if local_path.exists():
-        return
+        return True
+    
     print(f"{local_path} missing → downloading from {url}")
-
     local_path.parent.mkdir(parents=True, exist_ok=True)
-    r = requests.get(url)
-    r.raise_for_status()
-    local_path.write_bytes(r.content)
+    
+    try:
+        r = requests.get(url)
+        r.raise_for_status()
+        local_path.write_bytes(r.content)
+        print(f"Downloaded: {local_path}")
+        return True
+    except requests.RequestException as e:
+        if required:
+            raise
+        print(f"Warning: Could not download {url}: {e}")
+        return False
 
-    print(f"Downloaded: {local_path}")
+
+def load_metadata():
+    """Load model metadata from JSON file."""
+    global model_metadata
+    
+    if METADATA_PATH.exists():
+        try:
+            with open(METADATA_PATH, 'r') as f:
+                model_metadata = json.load(f)
+            print(f"Loaded model metadata: {model_metadata.get('model_version', 'unknown')}")
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"Warning: Could not load metadata: {e}")
+            model_metadata = None
+    else:
+        print("No model metadata file found")
+        model_metadata = None
+
+
+def parse_version(version_str: str) -> tuple:
+    """Parse a version string like 'v1.2.3' or 'Model-v1.2.3' into a tuple (1, 2, 3)."""
+    # Remove prefixes
+    v = version_str.replace("Model-", "").lstrip("v")
+    parts = v.split(".")
+    return tuple(int(p) for p in parts[:3])
+
+
+def check_compatibility():
+    """Check if the loaded model is compatible with this service version."""
+    if model_metadata is None:
+        print("Warning: No metadata available, skipping compatibility check")
+        return True
+    
+    compatibility = model_metadata.get("compatibility", {})
+    min_service_version = compatibility.get("min_service_version")
+    
+    if min_service_version:
+        try:
+            min_version = parse_version(min_service_version)
+            current_version = parse_version(SERVICE_VERSION)
+            
+            if current_version < min_version:
+                print(f"Warning: Model requires service version >= {min_service_version}, "
+                      f"but running {SERVICE_VERSION}")
+                return False
+            else:
+                print(f"Compatibility check passed: service {SERVICE_VERSION} >= {min_service_version}")
+        except (ValueError, IndexError) as e:
+            print(f"Warning: Could not parse versions for compatibility check: {e}")
+    
+    return True
 
 
 def ensure_model_available():
-    download_if_missing(MODEL_PATH, DEFAULT_MODEL_URL)
-    download_if_missing(PREPROCESSOR_PATH, DEFAULT_PREPROCESSOR_URL)
+    """Download model files if not present locally."""
+    download_if_missing(MODEL_PATH, DEFAULT_MODEL_URL, required=True)
+    download_if_missing(PREPROCESSOR_PATH, DEFAULT_PREPROCESSOR_URL, required=True)
+    download_if_missing(METADATA_PATH, DEFAULT_METADATA_URL, required=False)
 
+
+# Initialize on module load
 ensure_model_available()
+load_metadata()
+check_compatibility()
+
 model = joblib.load(MODEL_PATH)
 preprocessor = joblib.load(PREPROCESSOR_PATH)
+
+
+@app.route('/health', methods=['GET'])
+def health():
+    """
+    Health check endpoint with version information.
+    ---
+    responses:
+      200:
+        description: Service health status with version information
+        schema:
+          type: object
+          properties:
+            status:
+              type: string
+              example: healthy
+            service_version:
+              type: string
+              example: v1.0.0
+            model_version:
+              type: string
+              example: Model-v1.0.0
+            model_accuracy:
+              type: number
+              example: 0.9456
+            compatibility:
+              type: object
+    """
+    response = {
+        "status": "healthy",
+        "service_version": SERVICE_VERSION,
+        "model_version": model_metadata.get("model_version", "unknown") if model_metadata else "unknown",
+        "model_loaded": model is not None and preprocessor is not None
+    }
+    
+    if model_metadata:
+        response["model_accuracy"] = model_metadata.get("performance", {}).get("accuracy")
+        response["model_trained_at"] = model_metadata.get("trained_at")
+        response["model_commit"] = model_metadata.get("training_commit")
+        response["compatibility"] = model_metadata.get("compatibility", {})
+    
+    return jsonify(response)
+
+
+@app.route('/version', methods=['GET'])
+def version():
+    """
+    Get detailed version information.
+    ---
+    responses:
+      200:
+        description: Detailed version information for service and model
+        schema:
+          type: object
+    """
+    response = {
+        "service": {
+            "version": SERVICE_VERSION
+        },
+        "model": model_metadata if model_metadata else {"version": "unknown"}
+    }
+    return jsonify(response)
+
 
 @app.route('/predict', methods=['POST'])
 def predict():
@@ -83,15 +226,15 @@ def predict():
     res = {
         "result": prediction,
         "classifier": "decision tree",
-        "sms": sms
+        "sms": sms,
+        "service_version": SERVICE_VERSION,
+        "model_version": model_metadata.get("model_version", "unknown") if model_metadata else "unknown"
     }
     print(res)
     return jsonify(res)
 
+
 if __name__ == '__main__':
-  # Read port from environment so container runtime can override it
-  import os
-  # default to 8081 if MODEL_SERVICE_PORT is not set
-  port = int(os.getenv("MODEL_SERVICE_PORT", "8081"))
-  #clf = joblib.load(OUTPUT_PATH / 'model.joblib')
-  app.run(host="0.0.0.0", port=port, debug=True)
+    # Read port from environment so container runtime can override it
+    port = int(os.getenv("MODEL_SERVICE_PORT", "8081"))
+    app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
This PR addresses #10 and adds some improvements.

## Context: Managing Model and Source Code Versions

### Version drift in `pyproject.toml`

Presently a new container build workflow is run whenever a git tag is linked to a specific commit. However, the `pyproject` was failing to be a single source of truth: you could push a `git tag` without updating the `pyproject`.  You could push `git tag v1.10.1 and the `pyproject` could be stuck at `v1.9.0`.`

### Semantic Versioning for ML Models

The ML model and source code need different versioning strategies. Retraining the model is presently handled by running a manual github workflow. This workflow automatically bumps up the version (well, it wasn't, see #10) and how the versions were being bumped wasn't clear. We were using a conventional semantic versioning model which is not completely compatible: for example, what is a 'minor' patch in the context of an ML model?

Furthermore, there was no residual metadata attached to any of the models. Questions like "_what changed?_" and "_is it compatible with the rest of the service?_" could not be answered by man or machine.

## Proposal

### Enforce updating of the `pyproject.toml`. 

Pushing a new version is serious business, and it seems we're fine with that not being _fully_ automated (which I propose is fine!). If you push a new tag and fail to match the `pyproject.toml`, the build _will_ fail and you'll receive a message to that affect (see `.../docker-image.yml`)

### Managing the ML model versions

When you manually induce the training of a new model, you will be prompted to decide if you're bumping a patch, minor or major version: 

<img width="339" height="366" alt="Screenshot 2026-01-17 at 14 17 17" src="https://github.com/user-attachments/assets/ffd56755-c152-449c-beaa-3e54768aa3ad" />

Version numbers have different meanings than the conventional semantic versioning strategies and these are described in the `README`. 

When the model is trained, it also dumps some clear metadata (see `[https://github.com/doda25-team2/model-service/releases/tag/Model-v1.0.0]`). Furthermore, the docker image can be modified  to include compatibility flags. 


